### PR TITLE
Set CMakeFiles to create INTERFACE libraries

### DIFF
--- a/keyboard/CMakeLists.txt
+++ b/keyboard/CMakeLists.txt
@@ -1,8 +1,10 @@
 
-add_library(keyboard keyboard.c)
+add_library(keyboard INTERFACE)
+
+target_sources(keyboard INTERFACE keyboard.c)
 
 target_link_libraries(
-	keyboard PUBLIC
+	keyboard INTERFACE
 	pico_stdlib
 	pico_bootrom
 )

--- a/neopixel/CMakeLists.txt
+++ b/neopixel/CMakeLists.txt
@@ -1,7 +1,9 @@
-add_library(neopixel neopixel.c)
+add_library(neopixel INTERFACE)
+
+target_sources(neopixel INTERFACE neopixel.c)
 
 target_link_libraries(
-	neopixel PUBLIC
+	neopixel INTERFACE
 	pico_stdlib
 	hardware_pio
 )

--- a/oled/CMakeLists.txt
+++ b/oled/CMakeLists.txt
@@ -1,10 +1,12 @@
 
-add_library(oled oled.cpp)
+add_library(oled INTERFACE)
+
+target_sources(oled INTERFACE oled.cpp)
 
 add_subdirectory(pico-ssd1306)
 
 target_link_libraries(
-	oled PUBLIC
+	oled INTERFACE
 	pico_stdlib
 	hardware_i2c
 	pico_ssd1306

--- a/usb/CMakeLists.txt
+++ b/usb/CMakeLists.txt
@@ -1,16 +1,16 @@
-add_library(usb)
+add_library(usb INTERFACE)
 
-target_sources(usb PUBLIC
+target_sources(usb INTERFACE
         ${CMAKE_CURRENT_LIST_DIR}/usb.c
         ${CMAKE_CURRENT_LIST_DIR}/usb_descriptors.c
 )
 
 target_link_libraries(
-	usb PUBLIC
+	usb INTERFACE
 	pico_stdlib
 	tinyusb_board
 	tinyusb_device
 )
 
-target_include_directories(usb PUBLIC
+target_include_directories(usb INTERFACE
         ${CMAKE_CURRENT_LIST_DIR})


### PR DESCRIPTION
This change (and a matching set in submodules) prevents pico-sdk from being built for each subdirectory.